### PR TITLE
Start the SSH session inside the deployment directory

### DIFF
--- a/lib/capx/runner.rb
+++ b/lib/capx/runner.rb
@@ -28,10 +28,11 @@ module Capx
           puts 'capistrano server/user not found'
         else
           ssh_cmd = "ssh #{@user}@#{@server}"
-          ssh_cmd = "ssh -t #{@user}@#{@server} \"cd #{@deploy_to}; exec \$SHELL -l\"" unless @deploy_to.nil?
 
           if @switch == 'ssh'
             # call ssh
+            ssh_cmd = "ssh -t #{@user}@#{@server} \"cd #{@deploy_to}; exec \$SHELL -l\"" unless @deploy_to.nil?
+
             cmd = ssh_cmd
             execute_cmd(cmd)
           elsif @switch == 'disk'

--- a/lib/capx/runner.rb
+++ b/lib/capx/runner.rb
@@ -1,6 +1,7 @@
 module Capx
   class Runner
-    PATTERN = /server:?\s+[\'\"]([\w\-\.]+)[\'\"],\s+user:?\s+[\'\"]([\w\-\.]+)[\'\"]/
+    PATTERN     = /server:?\s+[\'\"]([\w\-\.]+)[\'\"],\s+user:?\s+[\'\"]([\w\-\.]+)[\'\"]/
+    DIR_PATTERN = /set :deploy_to,\s+[\'\"](?<path>(.+)\/([^\/]+))[\'\"]/
 
     def initialize(options)
       @stage  = options[:stage]
@@ -17,12 +18,18 @@ module Capx
             @server = match.captures[0]
             @user = match.captures[1] if @user.nil?
           end
+
+          if match = DIR_PATTERN.match(line)
+            @deploy_to = File.join(match[:path], 'current')
+          end
         end
 
         if @server.nil? || @user.nil?
           puts 'capistrano server/user not found'
         else
           ssh_cmd = "ssh #{@user}@#{@server}"
+          ssh_cmd = "ssh -t #{@user}@#{@server} \"cd #{@deploy_to}; exec \$SHELL -l\"" unless @deploy_to.nil?
+
           if @switch == 'ssh'
             # call ssh
             cmd = ssh_cmd

--- a/lib/capx/version.rb
+++ b/lib/capx/version.rb
@@ -1,5 +1,4 @@
 # main module for capx
 module Capx
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end
-  


### PR DESCRIPTION
This PR adds the `deploy_to` directory to the SSH command, if present. This allows you to start your SSH session inside the current deployment directory.